### PR TITLE
Add Missing CA Extension in req command

### DIFF
--- a/gencerts.sh
+++ b/gencerts.sh
@@ -12,7 +12,7 @@ touch certs/index.txt
 export SUBJECT_ALT_NAME=localhost
 export SUBJECT_ALT_IP=127.0.0.1
 
-[ -e certs/root.crt -a -e certs/root.key ] || openssl req -config openssl.cnf -x509 -nodes -newkey rsa -keyout certs/root.key -out certs/root.crt -subj '/C=NO/O=root'
+[ -e certs/root.crt -a -e certs/root.key ] || openssl req -config openssl.cnf -extensions v3_ca -x509 -nodes -newkey rsa -keyout certs/root.key -out certs/root.crt -subj '/C=NO/O=root'
 openssl req -config openssl.cnf -days 3650 -nodes -newkey rsa -keyout certs/scproxy.key -out certs/scproxy.csr -extensions v3_req -subj "/C=NO/CN=${SUBJECT_ALT_NAME}"
 openssl ca -config openssl.cnf -batch -rand_serial -out certs/scproxy.crt -notext -extensions v3_req -infiles certs/scproxy.csr
 


### PR DESCRIPTION
Firefox rejected the generated CA due to missing extension. (https://serverfault.com/a/919772)

This PR fixes it so it uses the ext_ca configuration, might seem that it has been unused.
```
X509v3 Basic Constraints: critical
                CA:TRUE
```
